### PR TITLE
Update evaluate.js

### DIFF
--- a/lib/util/evaluate.js
+++ b/lib/util/evaluate.js
@@ -4,6 +4,7 @@
 
 function evaluate(node) {
   // TODO: once we swap in math-parser, call its evaluate function instead
+  if (node.type === 'ConstantNode') return node.value
   return node.eval();
 }
 


### PR DESCRIPTION
There is a bug : eval() function doesn't exist on ConstantNode2 node. does it mean evaluate() function instead ?
so if node is a ConstantNode, I assume that evaluate(node) return its value, what else ?