### PR TITLE
Update evaluate.js

### DIFF
--- a/lib/util/evaluate.js
+++ b/lib/util/evaluate.js
@@ -4,8 +4,7 @@
 
 function evaluate(node) {
   // TODO: once we swap in math-parser, call its evaluate function instead
-  if (node.type === 'ConstantNode') return node.value
-  return node.eval();
+  return node.evaluate();
 }
 
 module.exports = evaluate;


### PR DESCRIPTION
It seems that eval() method dont work with mathjs V11.4.0, trying evaluate() instead